### PR TITLE
refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN rm -rf ./server/user/mods/SITCoop/.git
 
 FROM ubuntu:latest
 WORKDIR /opt/
-RUN apt update && apt upgrade -yq && apt install -yq dos2unix locales
+RUN apt update && apt upgrade -yq && apt install -yq dos2unix
 COPY --from=builder /opt/server /opt/srv
 COPY bullet.sh /opt/bullet.sh
 # Fix for Windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@
 ##
 
 FROM ubuntu:latest AS builder
-ARG SIT=-
-ARG SIT_BRANCH=master
-ARG SPT=-
-ARG SPT_BRANCH=3.8.0
+ARG SIT=HEAD^
+ARG SIT_BRANCH=development
+ARG SPT=HEAD^
+ARG SPT_BRANCH=3.8.1-DEV
 ARG NODE=20.11.1
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 WORKDIR /opt
 
 # Install git git-lfs curl
@@ -21,35 +22,38 @@ RUN git clone --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT-AKI/Server.git 
 
 ## Check out and git-lfs (specific commit --build-arg SPT=xxxx)
 WORKDIR /opt/srv/project 
-RUN git checkout $SPT || true
-RUN git-lfs fetch --all && git-lfs pull
+RUN git checkout $SPT
+RUN git-lfs pull
+
+## remove the encoding from aki - todo: find a better workaround
+RUN sed -i '/setEncoding/d' /opt/srv/project/src/Program.ts || true
 
 ## Install npm dependencies and run build
 RUN \. $HOME/.nvm/nvm.sh && npm install && npm run build:release -- --arch=$([ "$(uname -m)" = "aarch64" ] && echo arm64 || echo x64) --platform=linux
-
 ## Move the built server and clean up the source
 RUN mv build/ /opt/server/
 WORKDIR /opt
 RUN rm -rf srv/
 ## Grab SIT Coop Server Mod or continue if it exist
 RUN git clone --branch $SIT_BRANCH https://github.com/stayintarkov/SIT.Aki-Server-Mod.git ./server/user/mods/SITCoop 
-RUN cd ./server/user/mods/SITCoop && git checkout $SIT || true 
+RUN \. $HOME/.nvm/nvm.sh && cd ./server/user/mods/SITCoop && git checkout $SIT && npm install
 RUN rm -rf ./server/user/mods/SITCoop/.git
 
 FROM ubuntu:latest
 WORKDIR /opt/
-RUN apt update && apt upgrade -yq && apt install -yq dos2unix
+RUN apt update && apt upgrade -yq && apt install -yq dos2unix locales
 COPY --from=builder /opt/server /opt/srv
 COPY bullet.sh /opt/bullet.sh
 # Fix for Windows
 RUN dos2unix /opt/bullet.sh
 
 # Set permissions
-RUN chmod o+rwx /opt /opt/srv /opt/srv/* -R
+RUN chmod o+rwx /opt/* -R
 
 # Exposing ports
 EXPOSE 6969
 EXPOSE 6970
+EXPOSE 6971
 
 # Specify the default command to run when the container starts
 CMD bash ./bullet.sh

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Platform independent.
 
 5. Run the image once:
    ```bash
-   docker run --pull=never -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -p 6971:6971 -p 6972:6972 -it --name sitcoop sitcoop
+   docker run --pull=never -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -p 6971:6971 -it --name sitcoop sitcoop
    ```
    - ⚠️ If you don't set the -v (volume), you won't be able to do a required step!
 
    - On **Linux** you can include `--user $(id -u):$(id -g)`, this way, file ownership will be set to the user who started the container.
    ```bash
-   docker run --pull=never --user $(id -u):$(id -g) -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -it --name sitcoop sitcoop
+   docker run --pull=never --user $(id -u):$(id -g) -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -p 6971:6971 -it --name sitcoop sitcoop
    ```
 
 6. Go to your `./server` directory, delete `delete_me`, and optionally install additional mods, make config changes, etc.

--- a/bullet.sh
+++ b/bullet.sh
@@ -13,9 +13,8 @@ if [ -d "/opt/srv" ]; then
 	echo "Starting the server to generate all the required files"
 	cd /opt/server
 	chown $(id -u):$(id -g) ./* -Rf
-	nohup timeout --preserve-status 25s ./Aki.Server.exe >/dev/null 2>&1 
-	sleep 10
 	sed -i 's/127.0.0.1/0.0.0.0/g' /opt/server/Aki_Data/Server/configs/http.json
+	NODE_CHANNEL_FD= timeout --preserve-status 40s ./Aki.Server.exe </dev/null >/dev/null 2>&1 
 	echo "Follow the instructions to proceed!"
 	exit 0
 fi


### PR DESCRIPTION
- correct versioning for next rc
- set debconf noninteractive
- remove enforce for terminal setEncoding from sptaki before build
- installs npm packages in build (node_modules are not in the repo anymore)
- fix for improper pre-start (caused by nohup)
- simplify chmod for /opt