### PR TITLE
rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ### Linux template
 *~
+# Exclude any file inside the server and server-dev directory
+server/*
+server-dev/*
 
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,9 @@
-##
-## StayInTarkov LINUX Container
-##
+
+# StayInTarkov LINUX Container
+#
+# Copyright 2024 StayInTarkov
+# Use of this source code is governed by an MIT
+# license that can be found in the LICENSE file.
 
 ARG NODE=20.11.1
 
@@ -57,7 +60,7 @@ RUN if [ -n "$SIT_PR" ] && echo "$SIT_PR" | grep -Eq "^[0-9]+$"; then \
         git clone --single-branch --branch $SIT_BRANCH https://github.com/stayintarkov/SIT.Aki-Server-Mod.git sit && \
         cat /opt/sit_version.json | sed -n 's/.*"sha":"\([^"]*\)".*/\1/p' > /opt/sit/version; \
     fi
-RUN echo "SIT version: $(cat /opt/sit/version)"
+
 
 FROM node:${NODE}-alpine as builder
 # spt needs git to build:release
@@ -75,17 +78,17 @@ RUN rm -rf /opt/builder
 
 FROM alpine as server
 RUN apk update && \
-apk --no-cache add libgcc libstdc++ libc6-compat screen dos2unix && \
+apk --no-cache add libgcc libstdc++ libc6-compat curl screen dos2unix && \
 rm -rf /var/cache/apk/*
 
-FROM server
+FROM server as development
+ENV buildver "development"
 WORKDIR /opt
 COPY --from=builder /opt/server /opt/srv
 COPY ./entrypoint.alpine.sh /opt/entrypoint.sh
 # Fix for Windows
 RUN dos2unix /opt/entrypoint.sh
 # Set permissions
-#RUN chmod o+rwx /opt -R
 RUN chmod +x /opt/entrypoint.sh
 
 # Exposing ports
@@ -99,3 +102,7 @@ WORKDIR /opt/server
 ENTRYPOINT ["/opt/entrypoint.sh"]
 # Specify the default command to run when the container starts
 CMD ["/opt/server/Aki.Server.exe"]
+
+FROM development as release
+ENV buildver "release"
+RUN sed -n 's/.*"version": "\(.*\)".*/\1/p' /opt/srv/user/mods/SITCoop/package.json > /opt/srv/user/mods/SITCoop/version

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,6 +8,9 @@
 ARG NODE=20.11.1
 
 FROM alpine as git
+# https://lore.kernel.org/git/20240514181641.150112-1-sandals@crustytoothpaste.net/T/
+ENV GIT_CLONE_PROTECTION_ACTIVE=false
+# work around until git and git lfs resolve their differences.
 RUN apk add git git-lfs
 
 ARG SIT_COMMIT

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,7 +40,7 @@ RUN if [ -n "$SPT_PR" ] && echo "$SPT_PR" | grep -Eq "^[0-9]+$"; then \
 FROM git as sit
 WORKDIR /opt
 # invalidate cache and repull if upstream is different.
-ADD https://api.github.com/repos/stayintarkov/SIT.Aki-Server-Mod/git/refs/heads/development /opt/sit_version.json
+ADD https://api.github.com/repos/stayintarkov/SIT.Aki-Server-Mod/git/refs/heads/${SIT_BRANCH} /opt/sit_version.json
 # pull pr if provided, pull commit if provided, else single branch.
 RUN if [ -n "$SIT_PR" ] && echo "$SIT_PR" | grep -Eq "^[0-9]+$"; then \
         git clone https://github.com/stayintarkov/SIT.Aki-Server-Mod.git sit && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,101 @@
+##
+## StayInTarkov LINUX Container
+##
+
+ARG NODE=20.11.1
+
+FROM alpine as git
+RUN apk add git git-lfs
+
+ARG SIT_COMMIT
+ARG SIT_BRANCH=development
+ARG SIT_PR
+ARG SPT_COMMIT
+ARG SPT_BRANCH=master
+ARG SPT_PR
+
+
+FROM git as spt
+WORKDIR /opt
+# invalidate cache and repull if upstream is different.
+ADD https://dev.sp-tarkov.com/api/v1/repos/SPT-AKI/Server/git/refs/heads/${SPT_BRANCH} /opt/spt_version.json
+# pull pr if provided, pull commit if provided, else single branch.
+RUN if [ -n "$SPT_PR" ] && echo "$SPT_PR" | grep -Eq "^[0-9]+$"; then \
+        git clone https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        cd spt && \
+        git fetch origin pull/$SPT_PR/head:pr_$SPT_PR && \
+        git checkout pr_$SPT_PR && \
+        git-lfs pull; \
+    elif [ -n "$SPT_COMMIT" ]; then \
+        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        cd spt && \
+        git checkout $SPT_COMMIT && \
+        git-lfs pull; \
+    else \
+        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        cd spt && \
+        git-lfs pull; \
+    fi
+
+FROM git as sit
+WORKDIR /opt
+# invalidate cache and repull if upstream is different.
+ADD https://api.github.com/repos/stayintarkov/SIT.Aki-Server-Mod/git/refs/heads/development /opt/sit_version.json
+# pull pr if provided, pull commit if provided, else single branch.
+RUN if [ -n "$SIT_PR" ] && echo "$SIT_PR" | grep -Eq "^[0-9]+$"; then \
+        git clone https://github.com/stayintarkov/SIT.Aki-Server-Mod.git sit && \
+        cd sit && \
+        git fetch origin pull/$SIT_PR/head:pr_$SIT_PR && \
+        git checkout pr_$SIT_PR && \
+        echo "pr_${SIT_PR}" > /opt/sit/version; \
+    elif [ -n "$SIT_COMMIT" ]; then \
+        git clone --single-branch --branch $SIT_BRANCH https://github.com/stayintarkov/SIT.Aki-Server-Mod.git sit && \
+        cd sit && \
+        git checkout $SIT_COMMIT && \
+        echo "$SIT_COMMIT" > /opt/sit/version; \
+    else \
+        git clone --single-branch --branch $SIT_BRANCH https://github.com/stayintarkov/SIT.Aki-Server-Mod.git sit && \
+        cat /opt/sit_version.json | sed -n 's/.*"sha":"\([^"]*\)".*/\1/p' > /opt/sit/version; \
+    fi
+RUN echo "SIT version: $(cat /opt/sit/version)"
+
+FROM node:${NODE}-alpine as builder
+# spt needs git to build:release
+RUN apk add git
+COPY --from=spt /opt/spt /opt/builder
+WORKDIR /opt/builder/project
+RUN npm install
+RUN npm run build:release
+RUN mv build/ /opt/server/
+COPY --from=sit /opt/sit /opt/server/user/mods/SITCoop
+WORKDIR /opt/server/user/mods/SITCoop
+RUN npm install
+RUN rm -rf .git
+RUN rm -rf /opt/builder
+
+FROM alpine as server
+RUN apk update
+RUN apk --no-cache add libgcc libstdc++ libc6-compat screen dos2unix
+RUN rm -rf /var/cache/apk/*
+
+FROM server
+WORKDIR /opt
+COPY --from=builder /opt/server /opt/srv
+COPY ./entrypoint.alpine.sh /opt/entrypoint.sh
+# Fix for Windows
+RUN dos2unix /opt/entrypoint.sh
+# Set permissions
+#RUN chmod o+rwx /opt -R
+RUN chmod +x /opt/entrypoint.sh
+
+# Exposing ports
+EXPOSE 6969
+EXPOSE 6970
+EXPOSE 6971
+
+VOLUME ["/opt/server"]
+
+WORKDIR /opt/server
+ENTRYPOINT ["/opt/entrypoint.sh"]
+# Specify the default command to run when the container starts
+CMD ["/opt/server/Aki.Server.exe"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -74,9 +74,9 @@ RUN rm -rf .git
 RUN rm -rf /opt/builder
 
 FROM alpine as server
-RUN apk update
-RUN apk --no-cache add libgcc libstdc++ libc6-compat screen dos2unix
-RUN rm -rf /var/cache/apk/*
+RUN apk update && \
+apk --no-cache add libgcc libstdc++ libc6-compat screen dos2unix && \
+rm -rf /var/cache/apk/*
 
 FROM server
 WORKDIR /opt

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,21 +25,21 @@ ARG SPT_PR
 FROM git as spt
 WORKDIR /opt
 # invalidate cache and repull if upstream is different.
-ADD https://dev.sp-tarkov.com/api/v1/repos/SPT-AKI/Server/git/refs/heads/${SPT_BRANCH} /opt/spt_version.json
+ADD https://dev.sp-tarkov.com/api/v1/repos/SPT/Server/git/refs/heads/${SPT_BRANCH} /opt/spt_version.json
 # pull pr if provided, pull commit if provided, else single branch.
 RUN if [ -n "$SPT_PR" ] && echo "$SPT_PR" | grep -Eq "^[0-9]+$"; then \
-        git clone https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        git clone https://dev.sp-tarkov.com/SPT/Server.git spt && \
         cd spt && \
         git fetch origin pull/$SPT_PR/head:pr_$SPT_PR && \
         git checkout pr_$SPT_PR && \
         git-lfs pull; \
     elif [ -n "$SPT_COMMIT" ]; then \
-        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT/Server.git spt && \
         cd spt && \
         git checkout $SPT_COMMIT && \
         git-lfs pull; \
     else \
-        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT-AKI/Server.git spt && \
+        git clone --single-branch --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT/Server.git spt && \
         cd spt && \
         git-lfs pull; \
     fi

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,6 +6,7 @@
 # license that can be found in the LICENSE file.
 
 ARG NODE=20.11.1
+ARG BREAKING_CHANGE=false
 
 FROM alpine as git
 # https://lore.kernel.org/git/20240514181641.150112-1-sandals@crustytoothpaste.net/T/
@@ -85,6 +86,7 @@ apk --no-cache add libgcc libstdc++ libc6-compat curl screen dos2unix && \
 rm -rf /var/cache/apk/*
 
 FROM server as development
+ENV BREAKING=${BREAKING_CHANGE}
 ENV buildver "development"
 WORKDIR /opt
 COPY --from=builder /opt/server /opt/srv

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,11 +3,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.alpine
-      target: release
+     # target: development
       args:
         SIT_BRANCH: "development"
         SIT_COMMIT:
-        SIT_PR: 53
+        SIT_PR:
         SPT_BRANCH: "master"
         SPT_COMMIT:
         SPT_PR: 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ services:
         SPT_PR: 
     container_name: sitcoop-dev
     environment:
-      - BACKEND_IP=CHAGEME
+      - BACKEND_IP=CHANGEME
       #- SERVER_NAME=SIT
     volumes:
       - ./server-dev:/opt/server

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,17 +3,21 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.alpine
+      target: release
       args:
         SIT_BRANCH: "development"
         SIT_COMMIT:
-        SIT_PR: 
+        SIT_PR: 53
         SPT_BRANCH: "master"
         SPT_COMMIT:
         SPT_PR: 
     container_name: sitcoop-dev
+   # command: /bin/ash
     environment:
-      - BACKEND_IP=CHANGEME
-      #- SERVER_NAME=SIT
+      - BACKEND_IP=
+      - SERVER_NAME=
+      - HEADLESS=true
+      - UPDATE=false
     volumes:
       - ./server-dev:/opt/server
     ports:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -18,6 +18,7 @@ services:
       - SERVER_NAME=
       - HEADLESS=true
       - UPDATE=false
+      - LOG_REQUESTS=true
     volumes:
       - ./server-dev:/opt/server
     ports:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,12 +2,18 @@ services:
   tarkov-sitcoop-dev:
     build:
       context: .
+      dockerfile: Dockerfile.alpine
       args:
         SIT_BRANCH: "development"
-        SIT: "HEAD^"
-        SPT_BRANCH: "3.8.1-DEV"
-        SPT: "HEAD^"
+        SIT_COMMIT:
+        SIT_PR: 
+        SPT_BRANCH: "master"
+        SPT_COMMIT:
+        SPT_PR: 
     container_name: sitcoop-dev
+    environment:
+      - BACKEND_IP=CHAGEME
+      #- SERVER_NAME=SIT
     volumes:
       - ./server-dev:/opt/server
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   tarkov-sitcoop:
     image: stayintarkov/stayintarkov:latest
     container_name: sitcoop
+    environment:
+      - BACKEND_IP=CHANGEME
+     #- SERVER_NAME=SIT
     volumes:
       - ./server:/opt/server
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     image: stayintarkov/stayintarkov:latest
     container_name: sitcoop
     environment:
-      - BACKEND_IP=CHANGEME
-     #- SERVER_NAME=SIT
+      - BACKEND_IP=
+      - SERVER_NAME=
+      - HEADLESS=true
+      - UPDATE=false
     volumes:
       - ./server:/opt/server
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - SERVER_NAME=
       - HEADLESS=true
       - UPDATE=false
+      - LOG_REQUESTS=true
     volumes:
       - ./server:/opt/server
     ports:

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -5,9 +5,9 @@ EXISTING_VERSION=$(cat /opt/server/version 2>/dev/null)
 SIT_VERSION=$(cat /opt/srv/user/mods/SITCoop/version 2>/dev/null)
 
 # Grab user ENV input if exists else default
-SPT_IP=-0.0.0.0
+SPT_IP=0.0.0.0
 SPT_BACKEND_IP=${BACKEND_IP:-127.0.0.1}
-NEW_SERVER_NAME=${SERVER_NAME:-$SIT_VERSION}
+NEW_SERVER_NAME=${SERVER_NAME:-SIT $SIT_VERSION}
 
 
 echo "Stay In Tarkov Docker"
@@ -31,7 +31,7 @@ if [ -d "/opt/srv" ]; then
   echo "BACKEND_IP: $SPT_BACKEND_IP, updating http.json"
   sed -ir 's/"backendIp": .*,/"backendIp": "'$SPT_BACKEND_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
 
-  sed -i "s/\"serverName\": \".*\"/\"serverName\": \"SIT $NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
+  sed -i "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
   MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/Aki_Data/Server/configs/core.json)
   echo "Server Name: $MODIFIED_NAME, updating core.json"
   # boot server once in bg to generate files.

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -4,8 +4,8 @@
 EXISTING_VERSION=$(cat /opt/server/version 2>/dev/null)
 SIT_VERSION=$(cat /opt/srv/user/mods/SITCoop/version 2>/dev/null)
 
-# Grab container IP and user ENV input if exists else default
-SPT_IP=${CONTAINER_IP:-0.0.0.0}
+# Grab user ENV input if exists else default
+SPT_IP=-0.0.0.0
 SPT_BACKEND_IP=${BACKEND_IP:-127.0.0.1}
 NEW_SERVER_NAME=${SERVER_NAME:-$SIT_VERSION}
 

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -1,0 +1,81 @@
+#!/bin/ash
+
+# Read the existing version from the version file (if it exists)
+EXISTING_VERSION=$(cat /opt/server/version 2>/dev/null)
+SIT_VERSION=$(cat /opt/srv/user/mods/SITCoop/version 2>/dev/null)
+
+# Grab container IP and user ENV input if exists else default
+SPT_IP=${CONTAINER_IP:-0.0.0.0}
+SPT_BACKEND_IP=${BACKEND_IP:-127.0.0.1}
+NEW_SERVER_NAME=${SERVER_NAME:-$SIT_VERSION}
+
+
+echo "Stay In Tarkov Docker"
+echo "github.com/StayInTarkov"
+
+sit_setup() {
+if [ -d "/opt/srv" ]; then
+  start=$(date +%s)
+  echo "Started copying files to your volume/directory.. Please wait."
+  cp -r /opt/srv/* /opt/server/
+  rm -r /opt/srv
+  end=$(date +%s)
+
+  echo "Files copied to your machine in $(($end-$start)) seconds."
+  echo "Starting the server to generate all the required files"
+  cd /opt/server
+  chown $(id -u):$(id -g) ./* -Rf
+  echo "set SPT_IP to CONTAINER_IP: $SPT_IP, updating http.json"
+  sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
+
+  echo "BACKEND_IP: $SPT_BACKEND_IP, updating http.json"
+  sed -ir 's/"backendIp": .*,/"backendIp": "'$SPT_BACKEND_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
+
+  sed -i "s/\"serverName\": \".*\"/\"serverName\": \"SIT $NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
+  MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/Aki_Data/Server/configs/core.json)
+  echo "Server Name: $MODIFIED_NAME, updating core.json"
+  # boot server once in bg to generate files.
+  screen -L -Logfile "install.log" -d -m -S AkiServer ./Aki.Server.exe
+	while [ ! -f "/opt/server/user/mods/SITCoop/config/coopConfig.json" ]; do
+		sleep 10  # sleep till coopConfig.json is generated
+	done
+	screen -S AkiServer -X "^C" # kill Aki.Server
+  echo "Follow the instructions to proceed!"
+fi
+}
+
+# perform one-time server setup if no version file is found
+if [ ! -e "/opt/server/version" ]; then
+  echo "No version file found, running first-time setup..."
+
+  sit_setup
+
+  # will prevent setup from running again
+  echo "saving $SIT_VERSION to /opt/server/version"
+  printf "%s" "$SIT_VERSION" > /opt/server/version
+  echo "SIT Version installed: $(cat /opt/server/version)"
+  exit 0
+# existing version out of date run setup again.
+elif [ "$EXISTING_VERSION" != "$SIT_VERSION" ] && [ -d "/opt/srv" ]; then
+  echo "new SIT version: $SIT_VERSION found"
+  echo "existing SIT version: $EXISTING_VERSION outdated, regenerating files."
+
+  sit_setup
+
+  # will prevent setup from running again
+  echo "saving $SIT_VERSION to /opt/server/version"
+  printf "%s" "$SIT_VERSION" > /opt/server/version
+  echo "SIT Version updated: $(cat /opt/server/version)"
+  exit 0
+else
+  echo "existing SIT version: $EXISTING_VERSION"
+  echo "no update found, starting SIT..."
+fi
+
+# delete js n js.map files from existing mods (ignore SITCoop) and make sure server generates them fresh to prevent errors from copying windows artifact files.
+find /opt/server/user/mods -type d -name "SITCoop" -prune -o \
+-type f \( -name "*.js" -o -name "*.js.map" \) \
+-exec sh -c 'for x; do ts="${x%.*}.ts"; [ -f "$ts" ] && rm "$x"; done' _ {} +
+
+# continue to run whichever command was passed in (typically running Aki.Server.exe)
+exec "$@"

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -77,7 +77,8 @@ if [ -d "/opt/srv" ]; then
       echo "SIT Version updated: $(cat /opt/server/version)"
     else
       echo "UPDATE flag false, use -e UPPDATE=true if updating."
-      sleep 10
+      echo "Starting SIT Server in 5 seconds.."
+      sleep 5
     fi
   fi
 # quit if not headless

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -25,7 +25,7 @@ sit_setup() {
   start=$(date +%s)
   echo "Started copying files to your volume/directory.. Please wait."
   cp -r /opt/srv/* /opt/server/
-  rm -r /opt/srv
+  rm -rf /opt/srv
   end=$(date +%s)
 
   echo "Files copied to your machine in $(($end-$start)) seconds."
@@ -49,7 +49,10 @@ sit_setup() {
 	while [ ! -f "/opt/server/user/mods/SITCoop/config/coopConfig.json" ]; do
 		sleep 10  # sleep till coopConfig.json is generated
 	done
-	screen -S AkiServer -X "^C" # kill Aki.Server
+  # kill Aki.Server
+  pid=$(screen -ls | grep 'AkiServer' | awk '{print $1}' | cut -d '.' -f 1)
+  kill "$pid"
+	screen -S AkiServer -X "^C"
 }
 
 # perform one-time server setup if no version file is found

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -58,8 +58,7 @@ sit_setup() {
 	done
   # kill Aki.Server
   pid=$(screen -ls | grep 'AkiServer' | awk '{print $1}' | cut -d '.' -f 1)
-  kill "$pid"
-	screen -S AkiServer -X "^C"
+  kill -9 "$pid"
 }
 
 # perform one-time server setup if no version file is found

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -1,20 +1,27 @@
 #!/bin/ash
 
+# Copyright 2024 StayInTarkov
+# Use of this source code is governed by an MIT
+# license that can be found in the LICENSE file.
+
 # Read the existing version from the version file (if it exists)
 EXISTING_VERSION=$(cat /opt/server/version 2>/dev/null)
 SIT_VERSION=$(cat /opt/srv/user/mods/SITCoop/version 2>/dev/null)
 
 # Grab user ENV input if exists else default
-SPT_IP=0.0.0.0
-SPT_BACKEND_IP=${BACKEND_IP:-127.0.0.1}
+HEADLESS=${HEADLESS:-true}
+UPDATE=${UPDATE:-false}
+SPT_IP=${SPT_IP:-0.0.0.0}
+SPT_BACKEND_IP=${BACKEND_IP:-$(curl -s4 ipv4.icanhazip.com)}
 NEW_SERVER_NAME=${SERVER_NAME:-SIT $SIT_VERSION}
 
+#DBUG
+echo "DEBUG build: $buildver, HEADLESS: $HEADLESS, UPDATE: $UPDATE"
 
 echo "Stay In Tarkov Docker"
-echo "github.com/StayInTarkov"
+echo "github.com/StayInTarkov/SIT.Docker"
 
 sit_setup() {
-if [ -d "/opt/srv" ]; then
   start=$(date +%s)
   echo "Started copying files to your volume/directory.. Please wait."
   cp -r /opt/srv/* /opt/server/
@@ -25,7 +32,8 @@ if [ -d "/opt/srv" ]; then
   echo "Starting the server to generate all the required files"
   cd /opt/server
   chown $(id -u):$(id -g) ./* -Rf
-  echo "set SPT_IP: $SPT_IP, updating http.json"
+
+  echo "SPT_IP: $SPT_IP, updating http.json"
   sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
 
   echo "BACKEND_IP: $SPT_BACKEND_IP, updating http.json"
@@ -34,45 +42,54 @@ if [ -d "/opt/srv" ]; then
   sed -i "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
   MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/Aki_Data/Server/configs/core.json)
   echo "Server Name: $MODIFIED_NAME, updating core.json"
-  # boot server once in bg to generate files.
+
+  # remove previous install.log n boot server once in bg to generate files.
+  rm /opt/server/install.log
   screen -L -Logfile "install.log" -d -m -S AkiServer ./Aki.Server.exe
 	while [ ! -f "/opt/server/user/mods/SITCoop/config/coopConfig.json" ]; do
 		sleep 10  # sleep till coopConfig.json is generated
 	done
 	screen -S AkiServer -X "^C" # kill Aki.Server
-  echo "Follow the instructions to proceed!"
-fi
 }
 
 # perform one-time server setup if no version file is found
-if [ ! -e "/opt/server/version" ]; then
-  echo "No version file found, running first-time setup..."
+if [ -d "/opt/srv" ]; then
+  if [ ! -e "/opt/server/version" ]; then
+    echo "No version file found, running first-time setup..."
 
-  sit_setup
+    sit_setup
 
-  # will prevent setup from running again
-  echo "saving $SIT_VERSION to /opt/server/version"
-  printf "%s" "$SIT_VERSION" > /opt/server/version
-  echo "SIT Version installed: $(cat /opt/server/version)"
-  exit 0
-# existing version out of date run setup again.
-elif [ "$EXISTING_VERSION" != "$SIT_VERSION" ] && [ -d "/opt/srv" ]; then
-  echo "new SIT version: $SIT_VERSION found"
-  echo "existing SIT version: $EXISTING_VERSION outdated, regenerating files."
+    # will prevent setup from running again
+    echo "saving $SIT_VERSION to /opt/server/version"
+    printf "%s" "$SIT_VERSION" > /opt/server/version
+    echo "SIT Version installed: $(cat /opt/server/version)"
 
-  sit_setup
-
-  # will prevent setup from running again
-  echo "saving $SIT_VERSION to /opt/server/version"
-  printf "%s" "$SIT_VERSION" > /opt/server/version
-  echo "SIT Version updated: $(cat /opt/server/version)"
-  exit 0
-else
-  echo "existing SIT version: $EXISTING_VERSION"
-  echo "no update found, starting SIT..."
+# new SIT version found, reinstall if UPDATE flag present, else print version diff.
+  elif [ "$EXISTING_VERSION" != "$SIT_VERSION" ]; then
+    echo "new SIT version: $SIT_VERSION"
+    echo "existing SIT version: $EXISTING_VERSION"
+    if [ "$UPDATE" = true ]; then
+      echo "UPDATE flag true, installing update..."
+      sit_setup
+      # will prevent setup from running again
+      echo "saving $SIT_VERSION to /opt/server/version"
+      printf "%s" "$SIT_VERSION" > /opt/server/version
+      echo "SIT Version updated: $(cat /opt/server/version)"
+    else
+      echo "UPDATE flag false, use -e UPPDATE=true if updating."
+      sleep 10
+    fi
+  fi
+# quit if not headless
+  if [ "$HEADLESS" = false ]; then
+    echo "SIT.Docker setup is now complete!"
+    echo "You can configure and start your container."
+    exit 0
+  fi
 fi
 
 # delete js n js.map files from existing mods (ignore SITCoop) and make sure server generates them fresh to prevent errors from copying windows artifact files.
+echo "clearing mod *.js *.js.map artifact cache..."
 find /opt/server/user/mods -type d -name "SITCoop" -prune -o \
 -type f \( -name "*.js" -o -name "*.js.map" \) \
 -exec sh -c 'for x; do ts="${x%.*}.ts"; [ -f "$ts" ] && rm "$x"; done' _ {} +

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -15,6 +15,8 @@ SPT_IP=${SPT_IP:-0.0.0.0}
 SPT_BACKEND_IP=${BACKEND_IP:-$(curl -s4 ipv4.icanhazip.com)}
 SPT_LOG_REQUESTS=${LOG_REQUESTS:-true}
 NEW_SERVER_NAME=${SERVER_NAME:-SIT $SIT_VERSION}
+SPT_CONFIG_PATH=Aki_Data/Server/config
+#SPT_CONFIG_PATH=SPT_Data/Server/config 3.9
 
 #DBUG
 echo "DEBUG build: $buildver, HEADLESS: $HEADLESS, UPDATE: $UPDATE"
@@ -34,25 +36,27 @@ sit_setup() {
   cd /opt/server
   chown $(id -u):$(id -g) ./* -Rf
 
-  sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
-  MOD_IP=$(sed -n 's/.*"ip": "\(.*\)",/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/$SPT_CONFIG_PATH/http.json
+  MOD_IP=$(sed -n 's/.*"ip": "\(.*\)",/\1/p' /opt/server/$SPT_CONFIG_PATH/http.json)
   echo "SPT_IP: $MOD_IP, updating http.json"
 
-  sed -ir 's/"backendIp": .*,/"backendIp": "'$SPT_BACKEND_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
-  MOD_BIP=$(sed -n 's/.*"backendIp": "\(.*\)",/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  sed -ir 's/"backendIp": .*,/"backendIp": "'$SPT_BACKEND_IP'",/' /opt/server/$SPT_CONFIG_PATH/http.json
+  MOD_BIP=$(sed -n 's/.*"backendIp": "\(.*\)",/\1/p' /opt/server/$SPT_CONFIG_PATH/http.json)
   echo "BACKEND_IP: $MOD_BIP, updating http.json"
 
-  sed -ir "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
-  MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/Aki_Data/Server/configs/core.json)
+  sed -ir "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/$SPT_CONFIG_PATH/core.json
+  MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/$SPT_CONFIG_PATH/core.json)
   echo "serverName: $MODIFIED_NAME, updating core.json"
 
-  sed -ir 's/"logRequests": .*,/"logRequests": '"$SPT_LOG_REQUESTS"',/' /opt/server/Aki_Data/Server/configs/http.json
-  MOD_LOGQ=$(sed -n 's/.*"logRequests": \(.*\),/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  sed -ir 's/"logRequests": .*,/"logRequests": '"$SPT_LOG_REQUESTS"',/' /opt/server/$SPT_CONFIG_PATH/http.json
+  MOD_LOGQ=$(sed -n 's/.*"logRequests": \(.*\),/\1/p' /opt/server/$SPT_CONFIG_PATH/http.json)
   echo "logRequests: $MOD_LOGQ, updating http.json"
 
   # remove previous install.log n boot server once in bg to generate files.
   rm /opt/server/install.log
   screen -L -Logfile "install.log" -d -m -S AkiServer ./Aki.Server.exe
+  # 3.9 upcoming
+  # screen -L -Logfile "install.log" -d -m -S AkiServer ./SPT.Server.exe
 	while [ ! -f "/opt/server/user/mods/SITCoop/config/coopConfig.json" ]; do
 		sleep 10  # sleep till coopConfig.json is generated
 	done

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -90,8 +90,8 @@ if [ -d "/opt/srv" ]; then
       echo "saving $SIT_VERSION to /opt/server/version"
       printf "%s" "$SIT_VERSION" > /opt/server/version
       echo "SIT Version updated: $(cat /opt/server/version)"
-	elif [ "$FORCE" = true ]; then
-	  echo "Breaking SIT Update found, FORCE flag set, installing update..."
+    elif [ "$FORCE" = true ]; then
+      echo "Breaking SIT Update found, FORCE flag set, installing update..."
       sit_setup
       # will prevent setup from running again
       echo "saving $SIT_VERSION to /opt/server/version"

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -25,7 +25,7 @@ if [ -d "/opt/srv" ]; then
   echo "Starting the server to generate all the required files"
   cd /opt/server
   chown $(id -u):$(id -g) ./* -Rf
-  echo "set SPT_IP to CONTAINER_IP: $SPT_IP, updating http.json"
+  echo "set SPT_IP: $SPT_IP, updating http.json"
   sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
 
   echo "BACKEND_IP: $SPT_BACKEND_IP, updating http.json"

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -76,7 +76,7 @@ if [ -d "/opt/srv" ]; then
       printf "%s" "$SIT_VERSION" > /opt/server/version
       echo "SIT Version updated: $(cat /opt/server/version)"
     else
-      echo "UPDATE flag false, use -e UPPDATE=true if updating."
+      echo "UPDATE flag false, use -e UPDATE=true if updating."
       echo "Starting SIT Server in 5 seconds.."
       sleep 5
     fi

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -68,7 +68,7 @@ if [ -d "/opt/srv" ]; then
     echo "SIT Version installed: $(cat /opt/server/version)"
 
 # new SIT version found, reinstall if UPDATE flag present, else print version diff.
-  elif [ "$EXISTING_VERSION" != "$SIT_VERSION" ]; then
+  elif [ "$EXISTING_VERSION" != "$SIT_VERSION" ] || [ "$UPDATE" = true ]; then
     echo "new SIT version: $SIT_VERSION"
     echo "existing SIT version: $EXISTING_VERSION"
     if [ "$UPDATE" = true ]; then

--- a/entrypoint.alpine.sh
+++ b/entrypoint.alpine.sh
@@ -13,6 +13,7 @@ HEADLESS=${HEADLESS:-true}
 UPDATE=${UPDATE:-false}
 SPT_IP=${SPT_IP:-0.0.0.0}
 SPT_BACKEND_IP=${BACKEND_IP:-$(curl -s4 ipv4.icanhazip.com)}
+SPT_LOG_REQUESTS=${LOG_REQUESTS:-true}
 NEW_SERVER_NAME=${SERVER_NAME:-SIT $SIT_VERSION}
 
 #DBUG
@@ -33,15 +34,21 @@ sit_setup() {
   cd /opt/server
   chown $(id -u):$(id -g) ./* -Rf
 
-  echo "SPT_IP: $SPT_IP, updating http.json"
   sed -ir 's/"ip": .*,/"ip": "'$SPT_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
+  MOD_IP=$(sed -n 's/.*"ip": "\(.*\)",/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  echo "SPT_IP: $MOD_IP, updating http.json"
 
-  echo "BACKEND_IP: $SPT_BACKEND_IP, updating http.json"
   sed -ir 's/"backendIp": .*,/"backendIp": "'$SPT_BACKEND_IP'",/' /opt/server/Aki_Data/Server/configs/http.json
+  MOD_BIP=$(sed -n 's/.*"backendIp": "\(.*\)",/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  echo "BACKEND_IP: $MOD_BIP, updating http.json"
 
-  sed -i "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
+  sed -ir "s/\"serverName\": \".*\"/\"serverName\": \"$NEW_SERVER_NAME\"/" /opt/server/Aki_Data/Server/configs/core.json
   MODIFIED_NAME=$(sed -n 's/.*"serverName": "\([^"]*\)".*/\1/p' /opt/server/Aki_Data/Server/configs/core.json)
-  echo "Server Name: $MODIFIED_NAME, updating core.json"
+  echo "serverName: $MODIFIED_NAME, updating core.json"
+
+  sed -ir 's/"logRequests": .*,/"logRequests": '"$SPT_LOG_REQUESTS"',/' /opt/server/Aki_Data/Server/configs/http.json
+  MOD_LOGQ=$(sed -n 's/.*"logRequests": \(.*\),/\1/p' /opt/server/Aki_Data/Server/configs/http.json)
+  echo "logRequests: $MOD_LOGQ, updating http.json"
 
   # remove previous install.log n boot server once in bg to generate files.
   rm /opt/server/install.log


### PR DESCRIPTION
- alpine based multistage builder, 565.24mb compare to original 1.2gb give or take and a load less re-downloading.
- auto invalidate git clone cache if upstream updates
- pull PR if ARG exists (tested with https://github.com/stayintarkov/SIT.Aki-Server-Mod/pull/53)
- pull commit if ARG exists
- defaults to pull branch other wise
- uses commit_hash or pr_# as version file
- flushed out version system to check for updates.
- unified setup and entrypoint.sh
- use screen instead as it does not require editing of AKI source code for compat
- new ENVs
  - BACKEND_IP introduced in AKI 3.8.1
  - SERVER_NAME defaults to SIT + commit_hash
- deletes js and js.map artifacts from mods folder before booting to eliminate user error
- added sever and server-dev to git ignore.

I think that's everything, if it looks good I'll also update the documentation before merge or if you wanna stick to Ubuntu can also back port, but I think alpine is better suited.